### PR TITLE
Cron support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <cassandra-driver-core.version>2.1.0</cassandra-driver-core.version>
     <chaos.version>0.6.3</chaos.version>
     <commons-math3.version>3.2</commons-math3.version>
-    <cron-utils.version>3.1.0</cron-utils.version>
+    <cron-utils.version>3.1.1</cron-utils.version>
     <curator-framework.version>2.6.0</curator-framework.version>
     <guava.version>16.0.1</guava.version>
     <jgrapht.version>0.9.1</jgrapht.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <cassandra-driver-core.version>2.1.0</cassandra-driver-core.version>
     <chaos.version>0.6.3</chaos.version>
     <commons-math3.version>3.2</commons-math3.version>
+    <cron-utils.version>3.1.0</cron-utils.version>
     <curator-framework.version>2.6.0</curator-framework.version>
     <guava.version>16.0.1</guava.version>
     <jgrapht.version>0.9.1</jgrapht.version>
@@ -111,6 +112,11 @@
     </dependency>
 
     <!-- Everything else -->
+    <dependency>
+      <groupId>com.cronutils</groupId>
+      <artifactId>cron-utils</artifactId>
+      <version>${cron-utils.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -46,7 +46,7 @@ object JobUtils {
   
   def convertJobToStored(job: BaseJob): Option[StoredJob] = job match {
     case j: ScheduleBasedJob =>
-      Schedules.parse(j.schedule, j.scheduleTimeZone) map { parsedSched =>
+      Schedules.parse(j.schedule, j.scheduleTimeZone, scheduleType = j.scheduleType) map { parsedSched =>
         InternalScheduleBasedJob(
           parsedSched,
           scheduleTimeZone = j.scheduleTimeZone,

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -46,7 +46,7 @@ object JobUtils {
   
   def convertJobToStored(job: BaseJob): Option[StoredJob] = job match {
     case j: ScheduleBasedJob =>
-      Schedule.parse(j.schedule, j.scheduleTimeZone) map { parsedSched =>
+      Schedules.parse(j.schedule, j.scheduleTimeZone) map { parsedSched =>
         InternalScheduleBasedJob(
           parsedSched,
           scheduleTimeZone = j.scheduleTimeZone,
@@ -91,7 +91,8 @@ object JobUtils {
 
   def convertInternalScheduleToExternalScheduled(j: InternalScheduleBasedJob): ScheduleBasedJob = {
     ScheduleBasedJob(
-      schedule = j.scheduleData.toZeroOffsetISO8601Representation,
+      schedule = j.scheduleData.toStringRepresentation,
+      scheduleType = j.scheduleData.scheduleType,
       scheduleTimeZone = j.scheduleTimeZone,
       name = j.name,
       command = j.command,

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Jobs.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Jobs.scala
@@ -91,6 +91,7 @@ sealed trait ExternalJob extends BaseJob
 @JsonDeserialize(using = classOf[JobDeserializer])
 case class ScheduleBasedJob(
                              @JsonProperty schedule: String,
+                             @JsonProperty scheduleType: ScheduleType,
                              @JsonProperty override val name: String,
                              @JsonProperty override val command: String,
                              @JsonProperty override val epsilon: Period = Minutes.minutes(5).toPeriod,

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Schedule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Schedule.scala
@@ -1,44 +1,136 @@
 package org.apache.mesos.chronos.scheduler.jobs
 
+import java.util.TimeZone
+import java.util.logging.Logger
+
+import com.cronutils.model.{Cron, CronType => CronTypeEnum}
+import com.cronutils.model.definition.CronDefinitionBuilder
+import com.cronutils.model.time.ExecutionTime
+import com.cronutils.parser.CronParser
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.joda.time.{DateTime, Period}
+import org.joda.time.{DateTimeZone, DateTime, Period}
+
+import scala.util.{Failure, Success, Try}
 
 
-case class Schedule(@JsonProperty schedule: String,
-                    @JsonProperty scheduleTimeZone: String,
-                    @JsonProperty invocationTime: DateTime,
-                    @JsonProperty originTime: DateTime,
-                    @JsonProperty offset: Long = 0,
-                    @JsonProperty recurrences: Option[Long] = None,
-                    @JsonProperty period: Period) {
+sealed trait Schedule extends Product { self =>
 
+  type SType <: Schedule { type SType = self.SType }
 
-  def next: Option[Schedule] = {
+  def schedule: String
+  def scheduleTimeZone: String
+  def scheduleType: ScheduleType
+  def invocationTime: DateTime
+  def recurrences: Option[Long]
+  def next: Option[SType]
+  def toStringRepresentation: String
+}
+
+case class Iso8601Schedule(@JsonProperty schedule: String,
+                           @JsonProperty scheduleTimeZone: String,
+                           @JsonProperty invocationTime: DateTime,
+                           @JsonProperty originTime: DateTime,
+                           @JsonProperty offset: Long = 0,
+                           @JsonProperty recurrences: Option[Long] = None,
+                           @JsonProperty period: Period) extends Schedule {
+  type SType = Iso8601Schedule
+
+  val scheduleType = Iso8601Type
+
+  override def next: Option[Iso8601Schedule] = {
     if (recurrences.exists(_ == 0)) None
     else {
       val nextOffset = offset + 1
-      val nextInvocationTime = Schedule.addPeriods(originTime, period, nextOffset.asInstanceOf[Int] /* jodatime doesn't support longs in their plus methods. What to do about overflow? */)
+      val nextInvocationTime = Schedules.addPeriods(originTime, period, nextOffset.asInstanceOf[Int] /* jodatime doesn't support longs in their plus methods. What to do about overflow? */)
 
-      Some(Schedule(schedule, scheduleTimeZone, nextInvocationTime, originTime, nextOffset, recurrences.map(_ - 1), period))
+      Some(Iso8601Schedule(schedule, scheduleTimeZone, nextInvocationTime, originTime, nextOffset, recurrences.map(_ - 1), period))
     }
   }
 
-  def toZeroOffsetISO8601Representation: String = {
+  def toStringRepresentation: String = {
     Iso8601Expressions.create(recurrences.getOrElse(-1), invocationTime, period)
   }
 }
 
-object Schedule {
-  def parse(scheduleStr: String, timeZoneStr: String = ""): Option[Schedule] = {
-    Iso8601Expressions.parse(scheduleStr, timeZoneStr).map {
-      case (recurrences, start, period) =>
-        Schedule(scheduleStr, timeZoneStr, start, start, offset = 0, if (recurrences == -1) None else Some(recurrences), period)
+case class CronSchedule(@JsonProperty schedule: String,
+                        @JsonProperty scheduleTimeZone: String,
+                        @JsonProperty invocationTime: DateTime,
+                        @JsonProperty lastExecutionTime: DateTime,
+                         cron: Cron) extends Schedule {
+  type SType = CronSchedule
+  val recurrences = None
+  val scheduleType = CronType
+
+  override def next: Option[CronSchedule] = {
+    val tz = if(scheduleTimeZone != "") DateTimeZone.forID(scheduleTimeZone) else DateTimeZone.UTC
+    val currentTimeUserTZ = invocationTime.withZone(tz)
+    val nextExecUserTZ = ExecutionTime.forCron(cron).nextExecution(invocationTime)
+    val nextExec = nextExecUserTZ.withZone(DateTimeZone.UTC)
+
+    Some(copy(invocationTime = nextExec, lastExecutionTime = invocationTime))
+  }
+
+  def toStringRepresentation = cron.asString()
+}
+
+object Schedules {
+  val log = Logger.getLogger(getClass.getName)
+  val cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronTypeEnum.UNIX)
+
+  def parse(scheduleStr: String,
+            timeZoneStr: String = "",
+            scheduleType: ScheduleType = Iso8601Type,
+            currentTime: DateTime = DateTime.now(DateTimeZone.UTC)): Option[Schedule] = {
+
+    scheduleType match {
+      case Iso8601Type => parseIso8601Schedule(scheduleStr, timeZoneStr)
+      case CronType => parseCronSchedule(scheduleStr, timeZoneStr, currentTime)
     }
   }
 
+  def parseIso8601Schedule(scheduleStr: String, timeZoneStr: String = ""): Option[Iso8601Schedule] = {
+    Iso8601Expressions.parse(scheduleStr, timeZoneStr).map {
+      case (recurrences, start, period) =>
+        Iso8601Schedule(scheduleStr, timeZoneStr, start, start, offset = 0, if (recurrences == -1) None else Some(recurrences), period)
+    }
+  }
+
+  def parseCronSchedule(scheduleStr: String, timeZoneStr: String = "", currentTime: DateTime = DateTime.now(DateTimeZone.UTC)): Option[CronSchedule] = {
+    Try(parseCron(scheduleStr)) match {
+      case Failure(e) =>
+        log.warning(s"Failed to parse cron schedule: $scheduleStr, error was ${e.toString}")
+        None
+
+      case Success(cron) =>
+        CronSchedule(scheduleStr, timeZoneStr, currentTime, currentTime, cron).next
+    }
+  }
+
+  def parseCron(scheduleStr: String): Cron = {
+    new CronParser(cronDefinition).parse(scheduleStr)
+  }
+
+//  private def toUTC(dateTime: DateTime, timeZoneStr: String) = {
+//    timeZoneStr match {
+//      case "" =>
+//        dateTime
+//
+//      case timeZone =>
+//        val timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZoneStr))
+//        dateTime.withZoneRetainFields(timeZone)
+//    }
+//  }
 
   // replace with multiplied by?
   def addPeriods(origin: DateTime, period: Period, number: Int): DateTime = {
     origin.plus(period.multipliedBy(number))
   }
 }
+
+object ScheduleType {
+  def parse(s: String): Option[ScheduleType] = List(Iso8601Type, CronType).find(_.toString.toLowerCase == s.toLowerCase)
+}
+
+sealed trait ScheduleType
+case object Iso8601Type extends ScheduleType
+case object CronType extends ScheduleType

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Schedule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Schedule.scala
@@ -146,9 +146,17 @@ object Schedules {
 }
 
 object ScheduleType {
-  def parse(s: String): Option[ScheduleType] = List(Iso8601Type, CronType).find(_.toString.toLowerCase == s.toLowerCase)
+  def parse(s: String): Option[ScheduleType] = List(Iso8601Type, CronType).find(_.name.toLowerCase == s.toLowerCase)
 }
 
-sealed trait ScheduleType
-case object Iso8601Type extends ScheduleType
-case object CronType extends ScheduleType
+sealed trait ScheduleType {
+  def name: String
+}
+
+case object Iso8601Type extends ScheduleType {
+  val name = "Iso8601"
+}
+
+case object CronType extends ScheduleType {
+  val name = "Cron"
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
@@ -334,7 +334,7 @@ class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: Cassan
     var jobParents:Option[java.util.Set[String]] = None
     job match {
       case job: InternalScheduleBasedJob =>
-        jobSchedule = Some(job.scheduleData.toZeroOffsetISO8601Representation)
+        jobSchedule = Some(job.scheduleData.toStringRepresentation)
       case job: DependencyBasedJob =>
         jobParents = Some(job.parents.asJava)
     }
@@ -434,7 +434,7 @@ class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: Cassan
     var jobParents:Option[java.util.Set[String]] = None
     job match {
       case job: InternalScheduleBasedJob =>
-        jobSchedule = Some(job.scheduleData.toZeroOffsetISO8601Representation)
+        jobSchedule = Some(job.scheduleData.toStringRepresentation)
       case job: DependencyBasedJob =>
         jobParents = Some(job.parents.asJava)
     }

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
@@ -181,7 +181,7 @@ class JobSerializer extends JsonSerializer[BaseJob] {
         json.writeFieldName("schedule")
         json.writeString(schedJob.schedule)
         json.writeFieldName("scheduleType")
-        json.writeString(schedJob.scheduleType.toString)
+        json.writeString(schedJob.scheduleType.name)
         json.writeFieldName("scheduleTimeZone")
         json.writeString(schedJob.scheduleTimeZone)
       case iSchedJob: InternalScheduleBasedJob =>
@@ -189,7 +189,7 @@ class JobSerializer extends JsonSerializer[BaseJob] {
         json.writeString(iSchedJob.scheduleTimeZone)
 
         json.writeFieldName("scheduleType")
-        json.writeString(iSchedJob.scheduleData.scheduleType.toString)
+        json.writeString(iSchedJob.scheduleData.scheduleType.name)
 
         json.writeFieldName("scheduleData")
         json.writeStartObject()

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
@@ -85,7 +85,7 @@ class SerDeTest extends SpecificationWithJUnit {
         LikeConstraint("rack", "rack-[1-3]")
       )
 
-      val a = new ScheduleBasedJob("FOO/BAR/BAM", "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,
+      val a = new ScheduleBasedJob("FOO/BAR/BAM", Iso8601Type, "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,
         "fooexec", "fooflags", 7, "foo@bar.com", "Foo", "Test schedule-based job", "TODAY",
         "YESTERDAY", true, container = container, environmentVariables = environmentVariables,
         shell = true, arguments = arguments, softError = true, constraints = constraints)

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
@@ -14,7 +14,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
   "JobScheduler" should {
     "A job creates a failed task and then a successful task from a synchronous job" in {
       val epsilon = Hours.hours(2).toPeriod
-      val schedule = Schedule.parse("R5/2012-01-01T00:00:00.000Z/P1D").get
+      val schedule = Schedules.parseIso8601Schedule("R5/2012-01-01T00:00:00.000Z/P1D").get
       val job1 = new InternalScheduleBasedJob(schedule, "job1", "CMD", epsilon)
 
       val jobGraph = new JobGraph
@@ -26,7 +26,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
       scheduler.leader.set(true)
       scheduler.registerJob(job1, persist = true, startTime)
 
-      val nextInvocationTime = Schedule.parse("R4/2012-01-02T00:00:00.000Z/P1D").get.invocationTime
+      val nextInvocationTime = Schedules.parseIso8601Schedule("R4/2012-01-02T00:00:00.000Z/P1D").get.invocationTime
       val newStreams = scheduler.iteration(startTime, scheduler.streams)
       newStreams.head.schedule.invocationTime must_== nextInvocationTime
       newStreams.head.schedule.recurrences must_== Some(4)
@@ -49,7 +49,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
     "Executing a job updates the job counts and errors" in {
       val epsilon = Minutes.minutes(20).toPeriod
       val jobName = "FOO"
-      val job1 = new InternalScheduleBasedJob(scheduleData = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get,
+      val job1 = new InternalScheduleBasedJob(scheduleData = Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/PT1M").get,
         name = jobName, command = "fooo", epsilon = epsilon, retries = 0)
 
       val horizon = Minutes.minutes(5).toPeriod
@@ -81,7 +81,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that a disabled job does not run and does not execute dependant children." in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/PT1M").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = true)
       val job2 = new DependencyBasedJob(Set("job1"), name = "job2", command = "CMD", disabled = true)
@@ -111,7 +111,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that dependent jobs runs when they should" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/PT1M").get
 
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
@@ -171,7 +171,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that dependent jobs run even if their parents fail but have softError enabled" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val schedule = Schedule.parse("R/2012-01-01T00:01:00.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:01:00.000Z/PT1M").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
       val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
@@ -216,7 +216,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that dependent jobs don't run if their parents fail without softError enabled" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val schedule = Schedule.parse("R/2012-01-01T00:01:00.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:01:00.000Z/PT1M").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
       val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
@@ -256,7 +256,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that dependent jobs runs when they should after changing the jobgraph" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val schedule = Schedule.parse("R/2012-01-01T00:01:00.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:01:00.000Z/PT1M").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
       val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
@@ -351,7 +351,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that complex dependent jobs run when they should" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/PT1M").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
       val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
@@ -433,7 +433,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
       val epsilon = Minutes.minutes(20).toPeriod
       val date = DateTime.now(DateTimeZone.UTC)
       val fmt = ISODateTimeFormat.dateTime()
-      val schedule = Schedule.parse(s"R/${fmt.print(date)}/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule(s"R/${fmt.print(date)}/PT1M").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
       val job2 = new InternalScheduleBasedJob(scheduleData = schedule,

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
@@ -14,7 +14,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Construct a task for a given time when the schedule is within epsilon" in {
       val epsilon = Minutes.minutes(1).toPeriod
       val jobName = "FOO"
-      val schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R1/2012-01-01T00:00:01.000Z/PT1M").get
 
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
       val singleJobStream = new ScheduleStream(jobName, schedule)
@@ -35,7 +35,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Ignore a task that has been due past epsilon" in {
       val epsilon = Minutes.minutes(1).toPeriod
       val jobName = "FOO"
-      val schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R1/2012-01-01T00:00:01.000Z/PT1M").get
 
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
       val singleJobStream = new ScheduleStream(jobName, schedule)
@@ -53,7 +53,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Get an empty stream if no-op schedule is given" in {
       val epsilon = Minutes.minutes(1).toPeriod
       val jobName = "FOO"
-      val schedule: Schedule = Schedule.parse("R0/2012-01-01T00:00:01.000Z/PT1M").get
+      val schedule: Schedule = Schedules.parseIso8601Schedule("R0/2012-01-01T00:00:01.000Z/PT1M").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
 
       val singleJobStream = new ScheduleStream(jobName, schedule)
@@ -71,7 +71,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Old schedule stream is removed" in {
       val epsilon = Minutes.minutes(1).toPeriod
       val jobName = "FOO"
-      val schedule: Schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
+      val schedule: Schedule = Schedules.parseIso8601Schedule("R1/2012-01-01T00:00:01.000Z/PT1M").get
 
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
       val mockGraph = mock[JobGraph]
@@ -89,7 +89,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Old schedule streams are removed but newer ones are kept" in {
       val epsilon = Seconds.seconds(20).toPeriod
       val jobName = "FOO"
-      val schedule: Schedule = Schedule.parse("R10/2012-01-01T00:00:00.000Z/PT1M").get
+      val schedule: Schedule = Schedules.parseIso8601Schedule("R10/2012-01-01T00:00:00.000Z/PT1M").get
 
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
       //2012-01-01T00:00:00.000 -> 2012-01-01T00:09:00.000
@@ -123,7 +123,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Future task beyond time-horizon should not be scheduled" in {
       val epsilon = Seconds.seconds(60).toPeriod
       val jobName = "FOO"
-      val schedule: Schedule = Schedule.parse("R10/2012-01-10T00:00:00.000Z/PT1M").get
+      val schedule: Schedule = Schedules.parseIso8601Schedule("R10/2012-01-10T00:00:00.000Z/PT1M").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
 
       val jobStream = new ScheduleStream(jobName, schedule)
@@ -142,7 +142,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Multiple tasks must be scheduled if they're within epsilon and before time-horizon" in {
       val epsilon = Minutes.minutes(5).toPeriod
       val jobName = "FOO"
-      val schedule: Schedule = Schedule.parse("R60/2012-01-01T00:00:00.000Z/PT1S").get
+      val schedule: Schedule = Schedules.parseIso8601Schedule("R60/2012-01-01T00:00:00.000Z/PT1S").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
       val jobStream = new ScheduleStream(jobName, schedule)
 
@@ -162,7 +162,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Infinite task must be scheduled" in {
       val epsilon = Seconds.seconds(60).toPeriod
       val jobName = "FOO"
-      val schedule: Schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+      val schedule: Schedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/PT1M").get
       val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
 
 
@@ -208,7 +208,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
 
   "Removing tasks must also remove the streams" in {
     val epsilon = Seconds.seconds(60).toPeriod
-    val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+    val schedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/PT1M").get
     val job1 = new InternalScheduleBasedJob(schedule, "FOO", "CMD", epsilon)
     val job2 = new InternalScheduleBasedJob(schedule, "BAR", "CMD", epsilon)
 
@@ -243,12 +243,12 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     val jobName = "FOO"
     val jobCmd = "BARCMD"
 
-    val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1S").get
+    val schedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/PT1S").get
     val job1 = new InternalScheduleBasedJob(schedule, jobName, jobCmd, epsilon)
     val mockGraph = mock[JobGraph]
     mockGraph.lookupVertex(job1.name).returns(Some(job1))
 
-    val jobStream = new ScheduleStream(jobName, Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1S").get)
+    val jobStream = new ScheduleStream(jobName, Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/PT1S").get)
     val scheduler = mockScheduler(Period.hours(1), mock[TaskManager], mockGraph, store)
     scheduler.leader.set(true)
 
@@ -265,7 +265,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
 
   "Missed executions have to be skipped" in {
     val epsilon = Seconds.seconds(60).toPeriod
-    val job1 = new InternalScheduleBasedJob(Schedule.parse("R5/2012-01-01T00:00:00.000Z/P1D").get, "job1", "CMD", epsilon)
+    val job1 = new InternalScheduleBasedJob(Schedules.parseIso8601Schedule("R5/2012-01-01T00:00:00.000Z/P1D").get, "job1", "CMD", epsilon)
 
     val mockTaskManager = mock[TaskManager]
     val jobGraph = new JobGraph
@@ -278,6 +278,6 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     scheduler.registerJob(job1, persist = true, startTime)
 
     val newStreams = scheduler.iteration(startTime, scheduler.streams)
-    newStreams.head.schedule.invocationTime must_== Schedule.parse("R2/2012-01-04T00:00:00.000Z/P1D").get.invocationTime
+    newStreams.head.schedule.invocationTime must_== Schedules.parseIso8601Schedule("R2/2012-01-04T00:00:00.000Z/P1D").get.invocationTime
   }
 }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
@@ -14,7 +14,7 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
     val config = new SchedulerConfiguration {}
     val store = new MesosStatePersistenceStore(mockZKClient, config)
     val startTime = "R1/2012-01-01T00:00:01.000Z/PT1M"
-    val job = new InternalScheduleBasedJob(scheduleData = Schedule.parse(startTime).get, "sample-name", "sample-command")
+    val job = new InternalScheduleBasedJob(scheduleData = Schedules.parse(startTime).get, "sample-name", "sample-command")
     val mockScheduler = mock[JobScheduler]
 
     store.persistJob(job)
@@ -24,7 +24,7 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
   }
 
   "Can skip forward a job" in {
-    val schedule = Schedule.parse("R/2012-01-01T00:00:01.000Z/PT1M").get
+    val schedule = Schedules.parse("R/2012-01-01T00:00:01.000Z/PT1M").get
     val job = new InternalScheduleBasedJob(schedule, "sample-name", "sample-command")
     val now = new DateTime()
 
@@ -37,7 +37,7 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
   }
 
   "Can skip forward a job with a monthly period" in {
-    val schedule = Schedule.parse("R/2012-01-01T00:00:01.000Z/P1M").get
+    val schedule = Schedules.parse("R/2012-01-01T00:00:01.000Z/P1M").get
     val job = new InternalScheduleBasedJob(schedule, "sample-name", "sample-command")
     val now = new DateTime()
 
@@ -51,7 +51,7 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
   }
 
   "Can get job with arguments" in {
-    val schedule = Schedule.parse("R/2012-01-01T00:00:01.000Z/P1M").get
+    val schedule = Schedules.parse("R/2012-01-01T00:00:01.000Z/P1M").get
     val arguments = "--help"
     val command = "sample-command"
     val commandWithArguments = command + " " + arguments

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
@@ -70,4 +70,19 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
 
     JobUtils.isValidJobName(jobName)
   }
+
+  "Converts a job to internal representation" in {
+    val requested = ScheduleBasedJob(schedule = "* * * * *", name = "job", scheduleType = CronType, scheduleTimeZone = "UTC", command = "foo")
+
+    val maybeJob = JobUtils.convertJobToStored(requested).map(_.asInstanceOf[InternalScheduleBasedJob])
+    maybeJob.isDefined must_== true
+    val s = maybeJob.get.scheduleData
+    s.scheduleType must_== CronType
+    s.toStringRepresentation must_== "* * * * *"
+    s.scheduleTimeZone must_== "UTC"
+
+    val backToExternal = JobUtils.convertInternalScheduleToExternalScheduled(maybeJob.get)
+
+    backToExternal must_== requested
+  }
 }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleSpec.scala
@@ -1,0 +1,75 @@
+package org.apache.mesos.chronos.scheduler.jobs
+
+import org.joda.time.{DateTime, DateTimeZone}
+import org.specs2.mutable.SpecificationWithJUnit
+
+/**
+  */
+class ScheduleSpec extends SpecificationWithJUnit {
+
+  val fakeCurrentTime = DateTime.parse("2012-01-01T00:00:00Z")
+
+  "Schedules" should {
+    "ISO: Parse correctly" in {
+      val maybeSchedule = Schedules.parse("R3/2012-01-01T00:00:00.000Z/P1D", scheduleType = Iso8601Type)
+
+      maybeSchedule.isDefined must_== true
+      val asIso = maybeSchedule.get.asInstanceOf[Iso8601Schedule]
+
+      asIso.toStringRepresentation must_== "R3/2012-01-01T00:00:00.000Z/P1D"
+    }
+
+    "ISO: Fail to parse" in {
+      val failedSchedule = Schedules.parse("lol not a schedule", scheduleType = Iso8601Type)
+      failedSchedule.isDefined must_== false
+    }
+
+    "ISO: Handle getting the next occurance properly" in {
+      val maybeSchedule = Schedules.parse("R3/2012-01-01T00:00:00.000Z/P1D", scheduleType = Iso8601Type)
+
+      maybeSchedule.isDefined must_== true
+      val asIso = maybeSchedule.get.asInstanceOf[Iso8601Schedule]
+
+      asIso.invocationTime must_== DateTime.parse("2012-01-01T00:00:00.000Z")
+      asIso.next.get.invocationTime must_== DateTime.parse("2012-01-02T00:00:00.000Z")
+    }
+
+    "Cron: Parse correctly" in {
+      val maybeSchedule = Schedules.parse("* 0 * * *", scheduleType = CronType)
+
+      maybeSchedule.isDefined must_== true
+      val asCron = maybeSchedule.get.asInstanceOf[CronSchedule]
+
+      asCron.toStringRepresentation must_== "* 0 * * *"
+    }
+
+    "Cron: Fail to parse" in {
+      val cron = Schedules.parse("1 1 FOOBAR * *", scheduleType = CronType)
+
+      cron.isDefined must_== false
+    }
+
+    "Cron: Handle getting the next occurance properly" in {
+
+      val now = DateTime.parse("2012-02-29T01:00:00.000Z").withZoneRetainFields(DateTimeZone.UTC)
+      val maybeSchedule = Schedules.parse("0 0 * * *", currentTime = now, scheduleType = CronType)
+
+      maybeSchedule.isDefined must_== true
+      val asCron = maybeSchedule.get.asInstanceOf[CronSchedule]
+
+      val expectedNext = DateTime.parse("2012-03-01T00:00:00.000Z").withZoneRetainFields(DateTimeZone.UTC)
+      asCron.next.get.invocationTime must_== expectedNext
+    }
+
+    "Cron: handle time zones" in {
+      val now = DateTime.parse("2012-02-29T01:00:00.000Z").withZoneRetainFields(DateTimeZone.forID("US/Chicago"))
+      val maybeSchedule = Schedules.parse("0 0 * * *", currentTime = now, scheduleType = CronType)
+
+      maybeSchedule.isDefined must_== true
+      val asCron = maybeSchedule.get.asInstanceOf[CronSchedule]
+
+      val expectedNext = DateTime.parse("2012-03-01T00:00:00.000Z").withZoneRetainFields(DateTimeZone.forID("US/Chicago"))
+      asCron.next.get.invocationTime must_== expectedNext
+    }
+  }
+}

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStreamSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStreamSpec.scala
@@ -9,61 +9,74 @@ class ScheduleStreamSpec extends SpecificationWithJUnit {
 
   "ScheduleStream" should {
     "return a properly clipped schedule" in {
-      val orgSchedule = Schedule.parse("R3/2012-01-01T00:00:00.000Z/P1D").get
+      val orgSchedule = Schedules.parseIso8601Schedule("R3/2012-01-01T00:00:00.000Z/P1D").get
       val stream = new ScheduleStream(null, orgSchedule)
       stream.head must_== (null, orgSchedule)
 
       val nextSchedule = stream.tail.get.head._2
-      nextSchedule.invocationTime must_== Schedule.parse("R2/2012-01-02T00:00:00.000Z/P1D").get.invocationTime
-      nextSchedule.offset must_== 1
+      nextSchedule.invocationTime must_== Schedules.parseIso8601Schedule("R2/2012-01-02T00:00:00.000Z/P1D").get.invocationTime
+      nextSchedule.asInstanceOf[Iso8601Schedule].offset must_== 1
       nextSchedule.recurrences must_== Some(2)
 
       val nextSchedule2 = stream.tail.get.tail.get.head._2
-      nextSchedule2.invocationTime must_== Schedule.parse("R1/2012-01-03T00:00:00.000Z/P1D").get.invocationTime
-      nextSchedule2.offset must_== 2
+      nextSchedule2.invocationTime must_== Schedules.parseIso8601Schedule("R1/2012-01-03T00:00:00.000Z/P1D").get.invocationTime
+      nextSchedule2.asInstanceOf[Iso8601Schedule].offset must_== 2
       nextSchedule2.recurrences must_== Some(1)
 
       val nextSchedule3 = stream.tail.get.tail.get.tail.get.head._2
-      nextSchedule3.invocationTime must_== Schedule.parse("R0/2012-01-04T00:00:00.000Z/P1D").get.invocationTime
-      nextSchedule3.offset must_== 3
+      nextSchedule3.invocationTime must_== Schedules.parseIso8601Schedule("R0/2012-01-04T00:00:00.000Z/P1D").get.invocationTime
+      nextSchedule3.asInstanceOf[Iso8601Schedule].offset must_== 3
       nextSchedule3.recurrences must_== Some(0)
 
       nextSchedule3.next must_== None
     }
 
     "return a infinite schedule when no repetition is specified" in {
-      val orgSchedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/P1D").get
+      val orgSchedule = Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/P1D").get
       val stream = new ScheduleStream(null, orgSchedule)
       val infiniteSchedule = stream.head._2
       infiniteSchedule.invocationTime must_== orgSchedule.invocationTime
       infiniteSchedule.recurrences must_== None
 
-      stream.tail.get.head._2.invocationTime must_== Schedule.parse("R/2012-01-02T00:00:00.000Z/P1D").get.invocationTime
+      stream.tail.get.head._2.invocationTime must_== Schedules.parseIso8601Schedule("R/2012-01-02T00:00:00.000Z/P1D").get.invocationTime
     }
 
     "be convertible back to a string for simple cases" in {
-      val orgSchedule = new ScheduleStream(null, Schedule.parse("R/2012-01-01T00:00:00.000Z/P1D").get)
+      val orgSchedule = new ScheduleStream(null, Schedules.parseIso8601Schedule("R/2012-01-01T00:00:00.000Z/P1D").get)
       val newSchedule = orgSchedule.tail.get.tail.get.head._2
 
-      newSchedule.toZeroOffsetISO8601Representation must_== "R/2012-01-03T00:00:00.000Z/P1D"
+      newSchedule.toStringRepresentation must_== "R/2012-01-03T00:00:00.000Z/P1D"
     }
 
     "handle variable length months repetition correctly" in {
-      val orgSchedule = Schedule.parse("R/2012-01-31T00:00:00.000Z/P1M").get
+      val orgSchedule = Schedules.parseIso8601Schedule("R/2012-01-31T00:00:00.000Z/P1M").get
       val stream = new ScheduleStream(null, orgSchedule)
 
       val nextSchedule = stream.tail.get.head._2
-      nextSchedule.invocationTime must_== Schedule.parse("R/2012-02-29T00:00:00.000Z/P1M").get.invocationTime
-      nextSchedule.offset must_== 1
+      nextSchedule.invocationTime must_== Schedules.parseIso8601Schedule("R/2012-02-29T00:00:00.000Z/P1M").get.invocationTime
+      nextSchedule.asInstanceOf[Iso8601Schedule].offset must_== 1
       nextSchedule.recurrences must_== None
 
       val nextSchedule2 = stream.tail.get.tail.get.head._2
-      nextSchedule2.invocationTime must_== Schedule.parse("R/2012-03-31T00:00:00.000Z/P1M").get.invocationTime
-      nextSchedule2.offset must_== 2
+      nextSchedule2.invocationTime must_== Schedules.parseIso8601Schedule("R/2012-03-31T00:00:00.000Z/P1M").get.invocationTime
+      nextSchedule2.asInstanceOf[Iso8601Schedule].offset must_== 2
 
       val nextSchedule3 = stream.tail.get.tail.get.tail.get.head._2
-      nextSchedule3.invocationTime must_== Schedule.parse("R/2012-04-30T00:00:00.000Z/P1M").get.invocationTime
-      nextSchedule3.offset must_== 3
+      nextSchedule3.invocationTime must_== Schedules.parseIso8601Schedule("R/2012-04-30T00:00:00.000Z/P1M").get.invocationTime
+      nextSchedule3.asInstanceOf[Iso8601Schedule].offset must_== 3
+    }
+
+    "Generate cron schedules the same way" in {
+
+      // todo: fix for time zone
+      val now = DateTime.parse("2015-10-19T14:00:00.000Z").withZoneRetainFields(DateTimeZone.UTC)
+
+      val oneAM = Schedules.parseCronSchedule("0 1 * * *").get
+      val stream = new ScheduleStream("name", oneAM)
+
+      stream.head must_== ("name", DateTime.parse("2015-10-20T01:00:00.000Z"))
+      stream.tail.get.head must_== ("name", DateTime.parse("2015-10-21T01:00:00.000Z"))
+      stream.tail.get.tail.get.head must_== ("name", DateTime.parse("2015-10-22T01:00:00.000Z"))
     }
   }
 }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
@@ -31,7 +31,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
         mockJobGraph, null, MockJobUtils.mockFullObserver, mock[MetricRegistry], makeConfig(),
         mock[MesosOfferReviver])
 
-      val job = new InternalScheduleBasedJob(Schedule.parse("R/2012-01-01T00:00:01.000Z/PT1M").get, "test", "sample-command")
+      val job = new InternalScheduleBasedJob(Schedules.parse("R/2012-01-01T00:00:01.000Z/PT1M", scheduleType = Iso8601Type).get, "test", "sample-command")
 
       mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
       taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)
@@ -52,7 +52,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
       val taskManager = new TaskManager(mock[ListeningScheduledExecutorService], mockPersistencStore,
         mockJobGraph, null, MockJobUtils.mockFullObserver, mock[MetricRegistry], config, mockMesosOfferReviver)
 
-      val job = new InternalScheduleBasedJob(Schedule.parse("R/2012-01-01T00:00:01.000Z/PT1M").get, "test", "sample-command")
+      val job = new InternalScheduleBasedJob(Schedules.parse("R/2012-01-01T00:00:01.000Z/PT1M", scheduleType = Iso8601Type).get, "test", "sample-command")
       mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
 
       taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)
@@ -69,7 +69,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
       val taskManager = new TaskManager(mock[ListeningScheduledExecutorService], mockPersistencStore,
         mockJobGraph, null, MockJobUtils.mockFullObserver, mock[MetricRegistry], config, mockMesosOfferReviver)
 
-      val job = new InternalScheduleBasedJob(Schedule.parse("R/2012-01-01T00:00:01.000Z/PT1M").get, "test", "sample-command")
+      val job = new InternalScheduleBasedJob(Schedules.parse("R/2012-01-01T00:00:01.000Z/PT1M", scheduleType = Iso8601Type).get, "test", "sample-command")
       mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
 
       taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtilsSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtilsSpec.scala
@@ -10,8 +10,8 @@ class TaskUtilsSpec extends SpecificationWithJUnit with Mockito {
     "Get taskId" in {
       val schedule = "R/2012-01-01T00:00:01.000Z/P1M"
       val arguments = "-a 1 -b 2"
-      val job1 = new ScheduleBasedJob(schedule, "sample-name", "sample-command", arguments = List(arguments))
-      val job2 = new ScheduleBasedJob(schedule, "sample-name", "sample-command")
+      val job1 = new ScheduleBasedJob(schedule, Iso8601Type, "sample-name", "sample-command", arguments = List(arguments))
+      val job2 = new ScheduleBasedJob(schedule, Iso8601Type, "sample-name", "sample-command")
       val ts = 1420843781398L
       val due = new DateTime(ts)
 

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/state/PersistenceStoreSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/state/PersistenceStoreSpec.scala
@@ -11,7 +11,7 @@ class PersistenceStoreSpec extends SpecificationWithJUnit with Mockito {
 
     "Writing and reading ScheduledBasedJob a job works" in {
       val store = new MesosStatePersistenceStore(null, null)
-      val schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R1/2012-01-01T00:00:01.000Z/PT1M").get
       val job = new InternalScheduleBasedJob(scheduleData = schedule, name = "sample-name",
         command = "sample-command", successCount = 1L, epsilon = Hours.hours(1).toPeriod,
         executor = "fooexecutor", executorFlags = "args")
@@ -23,12 +23,31 @@ class PersistenceStoreSpec extends SpecificationWithJUnit with Mockito {
       job2.executor must_== job.executor
       job2.successCount must_== job.successCount
       job2.command must_== job.command
+    }
 
+    "Writing and reading Cron ScheduleBasedJobs works" in {
+      val store = new MesosStatePersistenceStore(null, null)
+      val schedule = Schedules.parseCronSchedule("0 14 * * MON-FRI").get
+      val job = new InternalScheduleBasedJob(scheduleData = schedule, name = "sample-cron",
+        command = "sample-command", successCount = 1L, epsilon = Hours.hours(1).toPeriod,
+        executor = "fooexecutor", executorFlags = "args")
+
+      store.persistJob(job)
+      val job2 = store.getJob(job.name)
+
+      job2.name must_== job.name
+      job2.getClass must_== classOf[InternalScheduleBasedJob]
+
+      val schedule2 = job2.asInstanceOf[InternalScheduleBasedJob].scheduleData
+      schedule2.invocationTime.compareTo(schedule.invocationTime) must_== 0
+      schedule2.schedule must_== schedule.schedule
+      schedule2.scheduleType must_== CronType
+      schedule2.asInstanceOf[CronSchedule].cron.asString() must_== schedule.cron.asString()
     }
 
     "Writing and reading DependencyBasedJob a job works" in {
       val store = new MesosStatePersistenceStore(null, null)
-      val schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
+      val schedule = Schedules.parseIso8601Schedule("R1/2012-01-01T00:00:01.000Z/PT1M").get
       val epsilon = Hours.hours(1).toPeriod
       val schedJob = new InternalScheduleBasedJob(scheduleData = schedule, name = "sample-name",
         command = "sample-command", epsilon = epsilon)


### PR DESCRIPTION
- support for cron
- one additional field in user facing DTO's, 'scheduleType', defaults for ISO8601 for backwards compatibility
- cron patterns executed in the time zone user passes, (UTC if no time zone passed)
